### PR TITLE
Add camera toggle feature with dynamic calendar resizing

### DIFF
--- a/boringNotch/ContentView.swift
+++ b/boringNotch/ContentView.swift
@@ -30,6 +30,8 @@ struct ContentView: View {
     @State private var gestureProgress: CGFloat = .zero
 
     @State private var haptics: Bool = false
+    
+    @State private var isCameraExpanded: Bool = false
 
     @Namespace var albumArtNamespace
 
@@ -169,7 +171,6 @@ struct ContentView: View {
         .shadow(color: ((vm.notchState == .open || isHovering) && Defaults[.enableShadow]) ? .black.opacity(0.6) : .clear, radius: Defaults[.cornerRadiusScaling] ? 10 : 5)
         .background(dragDetector)
         .environmentObject(vm)
-        .environmentObject(webcamManager)
     }
 
     @ViewBuilder
@@ -259,7 +260,10 @@ struct ContentView: View {
                   if vm.notchState == .open {
                       switch coordinator.currentView {
                           case .home:
-                              NotchHomeView(albumArtNamespace: albumArtNamespace)
+                          NotchHomeView(
+                            albumArtNamespace: albumArtNamespace,
+                            isCameraExpanded: $vm.isCameraExpanded
+                          )
                           case .shelf:
                               NotchShelfView()
                       }

--- a/boringNotch/components/Calendar/BoringCalendar.swift
+++ b/boringNotch/components/Calendar/BoringCalendar.swift
@@ -151,7 +151,8 @@ struct CalendarView: View {
     @EnvironmentObject var vm: BoringViewModel
     @StateObject private var calendarManager = CalendarManager()
     @State private var selectedDate = Date()
-
+    var isCameraExpanded: Bool
+    
     var body: some View {
         VStack(spacing: 8) {
             HStack {
@@ -275,7 +276,7 @@ struct EventListView: View {
 }
 
 #Preview {
-    CalendarView()
+    CalendarView(isCameraExpanded: false)
         .frame(width: 250)
         .padding(.horizontal)
         .background(.black)

--- a/boringNotch/components/Notch/BoringHeader.swift
+++ b/boringNotch/components/Notch/BoringHeader.swift
@@ -40,6 +40,20 @@ struct BoringHeader: View {
 
             HStack(spacing: 4) {
                 if vm.notchState == .open {
+                    Button(action: {
+                        vm.toggleCameraPreview()
+                    }) {
+                        Capsule()
+                            .fill(.black)
+                            .frame(width: 30, height: 30)
+                            .overlay {
+                                Image(systemName: "web.camera")
+                                    .foregroundColor(.white)
+                                    .padding()
+                                    .imageScale(.medium)
+                            }
+                    }
+                    .buttonStyle(PlainButtonStyle())
                     if Defaults[.settingsIconInNotch] {
                         SettingsLink(label: {
                             Capsule()

--- a/boringNotch/components/Notch/NotchHomeView.swift
+++ b/boringNotch/components/Notch/NotchHomeView.swift
@@ -184,6 +184,8 @@ struct NotchHomeView: View {
     @ObservedObject var coordinator = BoringViewCoordinator.shared
     let albumArtNamespace: Namespace.ID
 
+    @Binding var isCameraExpanded: Bool
+    
     var body: some View {
         Group {
             if !coordinator.firstLaunch {
@@ -198,15 +200,19 @@ struct NotchHomeView: View {
             MusicPlayerView(albumArtNamespace: albumArtNamespace)
 
             if Defaults[.showCalendar] {
-                CalendarView()
+                CalendarView(isCameraExpanded: isCameraExpanded)
                 .onHover { isHovering in
                     vm.isHoveringCalendar = isHovering
                 }
                 .environmentObject(vm)
             }
 
-            if Defaults[.showMirror] && webcamManager.cameraAvailable {
-                CameraPreviewView(webcamManager: webcamManager)
+            if Defaults[.showMirror] && vm.webcamManager.cameraAvailable {
+                CameraPreviewView(webcamManager: vm.webcamManager)
+                    .frame(
+                        width:  isCameraExpanded ? 150 : 0,
+                        height: isCameraExpanded ? 150 : 0
+                    )
                     .scaledToFit()
                     .opacity(vm.notchState == .closed ? 0 : 1)
                     .blur(radius: vm.notchState == .closed ? 20 : 0)
@@ -336,7 +342,12 @@ struct CustomSlider: View {
 }
 
 #Preview {
-    NotchHomeView(albumArtNamespace: Namespace().wrappedValue)
-        .environmentObject(BoringViewModel())
-        .environmentObject(WebcamManager())
+    let vm = BoringViewModel()
+    return NotchHomeView(
+        albumArtNamespace: Namespace().wrappedValue,
+        isCameraExpanded: .constant(false)
+    )
+    .environmentObject(vm)
+    .environmentObject(WebcamManager())
 }
+ 

--- a/boringNotch/models/BoringViewModel.swift
+++ b/boringNotch/models/BoringViewModel.swift
@@ -35,6 +35,10 @@ class BoringViewModel: NSObject, ObservableObject {
     @Published var notchSize: CGSize = getClosedNotchSize()
     @Published var closedNotchSize: CGSize = getClosedNotchSize()
     
+    @Published var webcamManager = WebcamManager()
+    @Published var isCameraExpanded: Bool = false
+    @Published var isRequestingAuthorization: Bool = false
+    
     deinit {
         destroy()
     }
@@ -100,6 +104,54 @@ class BoringViewModel: NSObject, ObservableObject {
         return noNotchAndFullscreen ? 0 : closedNotchSize.height
     }
 
+    func toggleCameraPreview() {
+        if isRequestingAuthorization {
+            return
+        }
+
+        switch webcamManager.authorizationStatus {
+        case .authorized:
+            if webcamManager.isSessionRunning {
+                webcamManager.stopSession()
+                isCameraExpanded = false
+            } else if webcamManager.cameraAvailable {
+                webcamManager.startSession()
+                isCameraExpanded = true
+            }
+
+        case .denied, .restricted:
+            DispatchQueue.main.async {
+                NSApp.setActivationPolicy(.regular)
+                NSApp.activate(ignoringOtherApps: true)
+
+                let alert = NSAlert()
+                alert.messageText = "Camera Access Required"
+                alert.informativeText = "Please allow camera access in System Settings."
+                alert.addButton(withTitle: "Open Settings")
+                alert.addButton(withTitle: "Cancel")
+
+                if alert.runModal() == .alertFirstButtonReturn {
+                    if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Camera") {
+                        NSWorkspace.shared.open(url)
+                    }
+                }
+
+                NSApp.setActivationPolicy(.accessory)
+                NSApp.deactivate()
+            }
+
+        case .notDetermined:
+            isRequestingAuthorization = true
+            webcamManager.checkAndRequestVideoAuthorization()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                self.isRequestingAuthorization = false
+            }
+
+        default:
+            break
+        }
+    }
+    
     func isMouseHovering(position: NSPoint = NSEvent.mouseLocation) -> Bool {
         let screenFrame = getScreenFrame(screen)
         if let frame = screenFrame {


### PR DESCRIPTION
This PR adds a simple but highly practical mirror toggle feature. The mirror (camera preview) can now be dynamically shown or hidden via a new camera icon in the header. Hiding the mirror gives more space for the calendar to expand, improving usability and allowing better use of screen real estate. This approach keeps the interface cleaner while still giving users quick access to the mirror when needed. The same toggle concept could also be extended to future features to optimize layout flexibility.

<img width="826" alt="Screenshot 2025-06-21 at 5 31 22 pm" src="https://github.com/user-attachments/assets/a5f531b3-2529-4a01-b5e8-bced8938e3e7" />
